### PR TITLE
use tape-promise, not baseline tape, for tests that return promises

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1645,6 +1645,16 @@
         }
       }
     },
+    "tape-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/tape-promise/-/tape-promise-4.0.0.tgz",
+      "integrity": "sha512-mNi5yhWAKDuNgZCfFKeZbsXvraVOf+I8UZG+lf+aoRrzX4+jd4mpNBjYh16/VcpEMUtS0iFndBgnfxxZbtyLFw==",
+      "dev": true,
+      "requires": {
+        "is-promise": "^2.1.0",
+        "onetime": "^2.0.0"
+      }
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "eslint-plugin-react": "^7.12.4",
     "prettier": "1.16.4",
     "rollup": "^1.2.2",
-    "tape": "^4.9.2"
+    "tape": "^4.9.2",
+    "tape-promise": "^4.0.0"
   },
   "directories": {
     "test": "test"

--- a/test/test-flow.js
+++ b/test/test-flow.js
@@ -1,4 +1,4 @@
-import { test } from 'tape';
+import test from 'tape-promise/tape';
 import makeFlowComm from '../index';
 
 test('tape works', t => {


### PR DESCRIPTION
Our unit tests use async/await, so they return Promises. 'tape' doesn't pay
attention to the return value of a test case, so it will drop that promise on
the floor. I think our tests happened to work anyways because we got lucky,
but we really ought to be using a runner like tape-promise that waits for the
promise to resolve before considering the test complete.